### PR TITLE
Add boto3 as required dependency of Zanshin CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![ Coverage badge ](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wiki/tenchi-security/zanshin-cli/python-coverage-comment-action-badge.json)
 [![PyPI version shields.io](https://img.shields.io/pypi/v/zanshincli.svg)](https://pypi.python.org/pypi/zanshincli/) [![PyPI pyversions](https://img.shields.io/pypi/pyversions/zanshincli.svg)](https://pypi.python.org/pypi/zanshincli/)
 
 # Zanshin CLI

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ typer~=0.3.2
 typer-cli~=0.0.12
 click~=7.1.2
 prettytable~=2.1.0
+httpx~=0.19.0
 zanshinsdk~=1.2.0
 twine~=3.8.0
+boto3~=1.21.19

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version=__version__,
     url='https://github.com/tenchi-security/zanshin-cli',
     license='Apache Software License',
-    install_requires=['zanshinsdk==1.2.0', 'typer==0.3.2', 'prettytable==2.1.0'],
+    install_requires=['zanshinsdk==1.2.0', 'typer==0.3.2', 'prettytable==2.1.0', 'boto3~=1.21.19'],
     tests_require=['pytest>=6.2,<7'],
     setup_requires=['pytest-runner>=5.3,<6'],
     packages=['zanshincli'],


### PR DESCRIPTION
## Goal

This PR adds `boto3` as a required dependency of this project.

## Tests

This was tested manually using Zanshin Dev and Prod environment. The tenchi-it AWS account was onboarded.
No unit tests were performed.

## Dependencies

Now `boto3` is a dependency that will be included with the Zanshin CLI.
Issue number from the [MegaBoard](https://github.com/orgs/tenchi-security/projects/14/views/10) #120 from the Megaboard

New stuff:
-  `boto3` as dependency
