### PR TITLE
Fix documentation generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,17 @@ jobs:
           md $HOME\\.tenchi
           echo $'[default]\napi_key = apikey\n' > $HOME\\.tenchi\\config
 
-      - name: Unit test
+      - name: Unit tests
         run: |
           pip install -r requirements.txt
+          make test
+
+      - name: Generate updated documentation
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          pip install pandoc
           rm README.md CLI.md
           make README.md
-          make test
 
       - name: Test coverage
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Unit test
         run: |
           pip install -r requirements.txt
+          rm README.md CLI.md
+          make README.md
           make test
-          make README.rst
 
       - name: Test coverage
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     name: Test and Coverage
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
     name: Run tests & display coverage
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 10
     steps:
       # DO NOT run actions/checkout@v2 here, for security reasons
       # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
           pip install -r requirements.txt
+          python setup.py develop
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
@@ -25,4 +26,4 @@ jobs:
           sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshincli/version.py setup.py
           rm CLI.md
           make CLI.md
-          #make pypi
+#         make pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Upload Python Package
 
 on:
-  pull_request:
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -24,6 +23,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshincli/version.py setup.py
-          rm CLI.md
-          make CLI.md
-#         make pypi
+          rm README.md
+          make pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  pull_request:
+#  release:
+#    types: [published]
 
 jobs:
   deploy:
@@ -21,5 +22,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshincli/version.py setup.py 
-          make pypi
+          sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshincli/version.py setup.py
+          rm CLI.md
+          make CLI.md
+          #make pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine
+          pip install --upgrade setuptools wheel twine pandoc
           pip install -r requirements.txt
           python setup.py develop
       - name: Build and publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshincli/version.py setup.py
-          rm README.md
+          rm README.md CLI.md
           make pypi

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ sdist:
 CLI.md: zanshincli/*.py
 	# Workaround for lack of typer-cli support on new versions
 	pip install typer==0.3.2 typer-cli
-
+	typer --help
+	typer --version
 	typer --app main_app zanshincli.main utils docs --output CLI.md --name zanshin
 
 	# Workaround for lack of typer-cli support on new versions

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ sdist:
 CLI.md: zanshincli/*.py
 	# Workaround for lack of typer-cli support on new versions
 	pip install typer==0.3.2 typer-cli
-	typer --help
 	typer --version
 	typer --app main_app zanshincli.main utils docs --output CLI.md --name zanshin
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # only required for testing
 pytest
 moto[all]~=3.1.16
-pandoc


### PR DESCRIPTION
Turns out testing the documentation generation is a lot trickier than expected. Found an issue where everything would work locally in my environment and finally found a way to solve it on Github Actions as well.

Added this forced documentation generation as a step on the unit tests again, so we can be sure to pick up on any problems prior to trying to release something to PyPI.

Also added timeouts to all three workflows to avoid runaway processes.