### PR TITLE
Install pandoc after wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine pandoc
+          pip install --upgrade setuptools wheel
+          pip install twine pandoc
           pip install -r requirements.txt
           python setup.py install
 


### PR DESCRIPTION
Addresses a warning on the `pandoc` package installation due to `wheel` not being installed yet. Separated the two installations in separate `pip` invocations.