### PR TITLE
Fix fat finger error on release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install -y pandoc
-          rm README.md CLI.md README.rst
+          rm -f README.md CLI.md README.rst
           make README.rst
 
       - name: Test coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate updated documentation
         run: |
           sudo apt-get install -y pandoc
-          rm README.md CLI.md README.s=rst
+          rm -f README.md CLI.md README.rst
           make README.rst
 
       - name: Build and publish


### PR DESCRIPTION
Fix incorrect file extension on release workflow file, and also add `-f` flag to `rm` so we don't fail if a documentation file doesn't exist.