### PR TITLE
Install twine using Ubuntu package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate updated documentation
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y pandoc
+          sudo apt-get install -y pandoc twine
           rm -f README.md CLI.md README.rst
           make README.rst
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,6 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
+          sudo apt-get install -y twine
           make pypitest
           make pypi


### PR DESCRIPTION
Another fix to the release workflow using the OS package for `twine`.