### PR TITLE
Fix API token used to upload to test PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build and publish to PyPI Test
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
           TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
         run: |
           sudo apt-get install -y twine


### PR DESCRIPTION
Created a new repository secret with the TestPyPI API token, and updated workflow file to use it for the respective upload step.