### PR TITLE
Fix "zanshin organization scan_target scan list" operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='__PACKAGE_VERSION__',
     url='https://github.com/tenchi-security/zanshin-cli',
     license='Apache Software License',
-    install_requires=['zanshinsdk==1.2.7', 'typer==0.6.1', 'prettytable==3.3.0', 'boto3~=1.24.39', 'boto3_type_annotations~=0.3.1'],
+    install_requires=['zanshinsdk==1.2.8', 'typer==0.6.1', 'prettytable==3.3.0', 'boto3~=1.24.39', 'boto3_type_annotations~=0.3.1'],
     tests_require=['pytest==7.1.2', 'moto[all]==3.1.16'],
     setup_requires=['pytest-runner==6.0.0'],
     packages=['zanshincli'],

--- a/zanshincli/main.py
+++ b/zanshincli/main.py
@@ -916,7 +916,7 @@ def _get_aws_accounts_from_organization(boto3_organizations_client: Boto3Organiz
 organization_scan_target_scan_app = typer.Typer()
 organization_scan_target_app.add_typer(organization_scan_target_scan_app, name="scan",
                                        help="Operations on scan targets from organizations the API key owner has direct"
-                                            "access to")
+                                            " access to")
 
 
 @organization_scan_target_scan_app.command(name='start')


### PR DESCRIPTION
Updated to Zanshin SDK 1.2.8 to fix the operation that lists scans on a particular scan target.

Tested manually executing the aforementioned command on an actual scan target.