### PR TITLE
Adds option for force-starting a scan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='__PACKAGE_VERSION__',
     url='https://github.com/tenchi-security/zanshin-cli',
     license='Apache Software License',
-    install_requires=['zanshinsdk==1.3.1', 'typer==0.6.1', 'prettytable==3.4.1', 'boto3~=1.24.66', 'boto3_type_annotations~=0.3.1'],
+    install_requires=['zanshinsdk==1.3.3', 'typer==0.6.1', 'prettytable==3.4.1', 'boto3~=1.24.66', 'boto3_type_annotations~=0.3.1'],
     tests_require=['pytest==7.1.3', 'moto[all]==3.1.18'],
     setup_requires=['pytest-runner==6.0.0'],
     packages=['zanshincli'],

--- a/zanshincli/main.py
+++ b/zanshincli/main.py
@@ -930,13 +930,14 @@ organization_scan_target_app.add_typer(organization_scan_target_scan_app, name="
 @organization_scan_target_scan_app.command(name='start')
 def organization_scan_target_scan_start(
         organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
-        scan_target_id: UUID = typer.Argument(..., help="UUID of the scan target")
+        scan_target_id: UUID = typer.Argument(..., help="UUID of the scan target"),
+        force: bool = typer.Option(False, help="Whether to force running a scan target that has state INVALID_CREDENTIAL or NEW")
 ):
     """
     Starts a scan on the specified scan target.
     """
     client = Client(profile=global_options['profile'])
-    dump_json(client.start_organization_scan_target_scan(organization_id, scan_target_id))
+    dump_json(client.start_organization_scan_target_scan(organization_id, scan_target_id, force))
 
 
 @organization_scan_target_scan_app.command(name='stop')


### PR DESCRIPTION
The force option was added to the API and is important when a brand new scan target is created or when verify succeeds but one wants to run the scan immediately after that. 

Tested: locally on a dev account