### PR TITLE
Fix default value for order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='__PACKAGE_VERSION__',
     url='https://github.com/tenchi-security/zanshin-cli',
     license='Apache Software License',
-    install_requires=['zanshinsdk==1.3.6', 'typer[all]==0.7.0', 'prettytable==3.5.0', 'boto3~=1.26.8', 'boto3_type_annotations~=0.3.1'],
+    install_requires=['zanshinsdk==1.5.0', 'typer[all]==0.7.0', 'prettytable==3.5.0', 'boto3~=1.26.8', 'boto3_type_annotations~=0.3.1'],
     tests_require=['pytest==7.2.0', 'moto[organizations,sts,s3]==4.0.8'],
     setup_requires=['pytest-runner==6.0.0'],
     packages=['zanshincli'],

--- a/zanshincli/main.py
+++ b/zanshincli/main.py
@@ -1006,8 +1006,8 @@ def alert_list(organization_id: UUID = typer.Argument(..., help="UUID of the org
                 updated_at_start: Optional[str] = typer.Option(None, help="Date updated starts at (format YYYY-MM-DDTHH:MM:SS)"),
                 updated_at_end: Optional[str] = typer.Option(None, help="Date updated ends at (format YYYY-MM-DDTHH:MM:SS)"),
                 search: Optional[str] = typer.Option("", help="Text to search for in the alerts"),
-                sort: Optional[SortOpts] = typer.Option("desc", help="Sort order"),
-                order: Optional[AlertsOrderOpts] = typer.Option([x.value for x in AlertsOrderOpts], help="")
+                sort: Optional[SortOpts] = typer.Option(SortOpts.DESC, help="Sort order"),
+                order: Optional[AlertsOrderOpts] = typer.Option(AlertsOrderOpts.SEVERITY, help="Field to sort results on")
                ):
     """
     List alerts from a given organization, with optional filters by scan target, state or severity.
@@ -1028,14 +1028,22 @@ def alert_list(organization_id: UUID = typer.Argument(..., help="UUID of the org
 def alert_following_list(organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
                          following_ids: Optional[List[UUID]] = typer.Option(None,
                                                                             help="Only list alerts from the specified"
-                                                                                 "scan targets."),
+                                                                                 " scan targets."),
                          states: Optional[List[AlertState]] = typer.Option(
                              [x.value for x in AlertState if x != AlertState.CLOSED],
                              help="Only list alerts in the specified states.", case_sensitive=False),
                          severity: Optional[List[AlertSeverity]] = typer.Option([x.value for x in AlertSeverity],
                                                                                 help="Only list alerts with the"
-                                                                                     "specified severities",
-                                                                                case_sensitive=False)
+                                                                                     " specified severities",
+                                                                                case_sensitive=False),
+                         created_at_start: Optional[str] = typer.Option(None, help="Date created starts at (format YYYY-MM-DDTHH:MM:SS)"),
+                         created_at_end: Optional[str] = typer.Option(None, help="Date created ends at (format YYYY-MM-DDTHH:MM:SS)"),
+                         updated_at_start: Optional[str] = typer.Option(None, help="Date updated starts at (format YYYY-MM-DDTHH:MM:SS)"),
+                         updated_at_end: Optional[str] = typer.Option(None, help="Date updated ends at (format YYYY-MM-DDTHH:MM:SS)"),
+                         search: Optional[str] = typer.Option("", help="Text to search for in the alerts"),
+                         sort: Optional[SortOpts] = typer.Option(SortOpts.DESC, help="Sort order"),
+                         order: Optional[AlertsOrderOpts] = typer.Option(AlertsOrderOpts.SEVERITY, 
+                                                                         help="Field to sort results on")
                          ):
     """
     List following alerts from a given organization, with optional filters by following ids, state or severity.
@@ -1043,7 +1051,9 @@ def alert_following_list(organization_id: UUID = typer.Argument(..., help="UUID 
     client = Client(profile=global_options['profile'])
     output_iterable(
         client.iter_following_alerts(organization_id=organization_id, following_ids=following_ids, states=states,
-                                     severities=severity)
+                                     created_at_start=created_at_start, created_at_end=created_at_end,
+                                     updated_at_start=updated_at_start, updated_at_end=updated_at_end,
+                                     severities=severity, search=search, sort=sort, order=order)
     )
 
 


### PR DESCRIPTION
* Set a sane default value for `order`;
* Add missing fields and documentations for `alert list` and `alert list_following` commands;
* Update SDK to version 1.5.0 for fixes and updates.

Resolves #54 to address issue raised by @kleber-cs .