### PR TITLE
add summaries new granular share routes

### DIFF
--- a/src/bin/alerts.py
+++ b/src/bin/alerts.py
@@ -31,7 +31,7 @@ def alert_list(
         None, help="Only lists alerts from the specified tags"
     ),
     include_empty_scan_target_tags: Optional[bool] = typer.Option(
-        None, help="Include alerts without tags on the list"
+        None, help="Include alerts from scan targets without tags"
     ),
     cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
     order: Optional[AlertsOrderOpts] = typer.Option(
@@ -64,7 +64,7 @@ def alert_following_list(
         None, help="Only lists alerts from the specified tags"
     ),
     include_empty_following_tags: Optional[bool] = typer.Option(
-        None, help="Include alerts without tags on the list"
+        None, help="Include alerts from scan targets without tags"
     ),
     cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
     order: Optional[AlertsOrderOpts] = typer.Option(
@@ -198,7 +198,7 @@ def grouped_alert_following_list(
         None, help="Only lists alerts from the specified tags"
     ),
     include_empty_following_tags: Optional[bool] = typer.Option(
-        None, help="Include alerts without tags on the list"
+        None, help="Include alerts from scan targets without tags"
     ),
     cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
     order: Optional[AlertsOrderOpts] = typer.Option(

--- a/src/bin/alerts.py
+++ b/src/bin/alerts.py
@@ -24,42 +24,16 @@ app = typer.Typer()
 @app.command(name="list")
 def alert_list(
     organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
-    scan_target_id: Optional[List[UUID]] = typer.Option(
+    scan_target_ids: Optional[List[UUID]] = typer.Option(
         None, help="Only list alerts from the specified scan targets"
     ),
-    states: Optional[List[AlertState]] = typer.Option(
-        [
-            x.value
-            for x in AlertState
-            if x != AlertState.CLOSED and x != AlertState.ACTIVE
-        ],
-        help="Only list alerts in the specified states",
-        case_sensitive=False,
+    scan_target_tags: Optional[List[str]] = typer.Option(
+        None, help="Only lists alerts from the specified tags"
     ),
-    severity: Optional[List[AlertSeverity]] = typer.Option(
-        [x.value for x in AlertSeverity],
-        help="Only list alerts with the specified severities",
-        case_sensitive=False,
+    include_empty_scan_target_tags: Optional[bool] = typer.Option(
+        None, help="Include alerts without tags on the list"
     ),
-    language: Optional[Languages] = typer.Option(
-        Languages.EN_US.value,
-        help="Show alert titles in the specified language",
-        case_sensitive=False,
-    ),
-    created_at_start: Optional[str] = typer.Option(
-        None, help="Date created starts at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    created_at_end: Optional[str] = typer.Option(
-        None, help="Date created ends at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    updated_at_start: Optional[str] = typer.Option(
-        None, help="Date updated starts at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    updated_at_end: Optional[str] = typer.Option(
-        None, help="Date updated ends at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    search: Optional[str] = typer.Option("", help="Text to search for in the alerts"),
-    sort: Optional[SortOpts] = typer.Option(SortOpts.DESC, help="Sort order"),
+    cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
     order: Optional[AlertsOrderOpts] = typer.Option(
         AlertsOrderOpts.SEVERITY, help="Field to sort results on"
     ),
@@ -71,16 +45,10 @@ def alert_list(
     output_iterable(
         client.iter_alerts(
             organization_id=organization_id,
-            scan_target_ids=scan_target_id,
-            states=states,
-            severities=severity,
-            language=language,
-            created_at_start=created_at_start,
-            created_at_end=created_at_end,
-            updated_at_start=updated_at_start,
-            updated_at_end=updated_at_end,
-            search=search,
-            sort=sort,
+            scan_target_ids=scan_target_ids,
+            scan_target_tags=scan_target_tags,
+            include_empty_scan_target_tags=include_empty_scan_target_tags,
+            cursor=cursor,
             order=order,
         )
     )
@@ -92,34 +60,13 @@ def alert_following_list(
     following_ids: Optional[List[UUID]] = typer.Option(
         None, help="Only list alerts from the specified scan targets"
     ),
-    states: Optional[List[AlertState]] = typer.Option(
-        [
-            x.value
-            for x in AlertState
-            if x != AlertState.CLOSED and x != AlertState.ACTIVE
-        ],
-        help="Only list alerts in the specified states",
-        case_sensitive=False,
+    following_tags: Optional[List[UUID]] = typer.Option(
+        None, help="Only lists alerts from the specified tags"
     ),
-    severity: Optional[List[AlertSeverity]] = typer.Option(
-        [x.value for x in AlertSeverity],
-        help="Only list alerts with the" " specified severities",
-        case_sensitive=False,
+    include_empty_following_tags: Optional[bool] = typer.Option(
+        None, help="Include alerts without tags on the list"
     ),
-    created_at_start: Optional[str] = typer.Option(
-        None, help="Date created starts at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    created_at_end: Optional[str] = typer.Option(
-        None, help="Date created ends at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    updated_at_start: Optional[str] = typer.Option(
-        None, help="Date updated starts at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    updated_at_end: Optional[str] = typer.Option(
-        None, help="Date updated ends at (format YYYY-MM-DDTHH:MM:SS)"
-    ),
-    search: Optional[str] = typer.Option("", help="Text to search for in the alerts"),
-    sort: Optional[SortOpts] = typer.Option(SortOpts.DESC, help="Sort order"),
+    cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
     order: Optional[AlertsOrderOpts] = typer.Option(
         AlertsOrderOpts.SEVERITY, help="Field to sort results on"
     ),
@@ -132,14 +79,9 @@ def alert_following_list(
         client.iter_following_alerts(
             organization_id=organization_id,
             following_ids=following_ids,
-            states=states,
-            created_at_start=created_at_start,
-            created_at_end=created_at_end,
-            updated_at_start=updated_at_start,
-            updated_at_end=updated_at_end,
-            severities=severity,
-            search=search,
-            sort=sort,
+            following_tags=following_tags,
+            include_empty_following_tags=include_empty_following_tags,
+            cursor=cursor,
             order=order,
         )
     )
@@ -252,19 +194,15 @@ def grouped_alert_following_list(
     following_ids: Optional[List[UUID]] = typer.Option(
         None, help="Only list alerts from the specified scan targets"
     ),
-    state: Optional[List[AlertState]] = typer.Option(
-        [
-            x.value
-            for x in AlertState
-            if x != AlertState.CLOSED and x != AlertState.ACTIVE
-        ],
-        help="Only list alerts in the specified states",
-        case_sensitive=False,
+    following_tags: Optional[List[UUID]] = typer.Option(
+        None, help="Only lists alerts from the specified tags"
     ),
-    severity: Optional[List[AlertSeverity]] = typer.Option(
-        [x.value for x in AlertSeverity],
-        help="Only list alerts with the specified severities",
-        case_sensitive=False,
+    include_empty_following_tags: Optional[bool] = typer.Option(
+        None, help="Include alerts without tags on the list"
+    ),
+    cursor: Optional[str] = typer.Option(None, help="Cursor for pagination"),
+    order: Optional[AlertsOrderOpts] = typer.Option(
+        AlertsOrderOpts.SEVERITY, help="Field to sort results on"
     ),
 ):
     """
@@ -275,8 +213,10 @@ def grouped_alert_following_list(
         client.iter_grouped_following_alerts(
             organization_id=organization_id,
             following_ids=following_ids,
-            states=state,
-            severities=severity,
+            following_tags=following_tags,
+            include_empty_following_tags=include_empty_following_tags,
+            cursor=cursor,
+            order=order,
         )
     )
 

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -2,7 +2,11 @@ from typing import List, Optional
 from uuid import UUID
 
 import typer
-from zanshinsdk import Client
+from zanshinsdk import (
+    Client,
+    AlertSeverity,
+    ScanTargetKind
+)
 
 import src.config.sdk as sdk_config
 from src.lib.utils import dump_json
@@ -10,71 +14,57 @@ from src.lib.utils import dump_json
 app = typer.Typer()
 
 
-@app.command(name="alert")
-def summary_alert(
-    organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
-    scan_target_id: Optional[List[UUID]] = typer.Option(
-        None,
-        help="Only summarize alerts from the specified scan targets, defaults to all",
-    ),
-):
-    """
-    Gets a summary of the current state of alerts for an organization, both in total and broken down by scan target.
-    """
-    client = Client(profile=sdk_config.profile)
-
-    dump_json(client.get_alert_summaries(organization_id, scan_target_id))
-
-
-@app.command(name="alert_following")
-def summary_alert_following(
+@app.command(name="scan_targets_following")
+def summary_scan_targets_following(
     organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
     following_ids: Optional[List[UUID]] = typer.Option(
-        None,
-        help="Only summarize alerts from the specified following, defaults to all",
+        None, help="Only summarize scan targets from the specified following ids"
     ),
+    following_tags: Optional[List[str]] = typer.Option(
+        None, help="Only summarize scan targets from the specified following tags"
+    ),
+    scan_target_kinds: Optional[List[ScanTargetKind]] = typer.Option(
+        None, help="Only summarize scan targets from the specified kinds"
+    ),
+    alert_severities: Optional[List[AlertSeverity]] = typer.Option(
+        None, help="Only summarize scan targets from the specified severities"
+    )
 ):
-    """
-    Gets a summary of the current state of alerts for followed organizations.
-    """
     client = Client(profile=sdk_config.profile)
+    dump_json(
+        client.get_scan_targets_following_summary(
+            organization_id,
+            following_ids,
+            following_tags,
+            scan_target_kinds,
+            alert_severities
+        )
+    )
 
-    dump_json(client.get_following_alert_summaries(organization_id, following_ids))
 
-
-@app.command(name="scan")
-def summary_scan(
+@app.command(name="scan_targets_detail")
+def summary_scan_targets_detail(
     organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
     scan_target_ids: Optional[List[UUID]] = typer.Option(
-        None,
-        help="Only summarize alerts from the specified scan targets, defaults to all",
+        None, help="Only summarize scan targets from the specified scan target ids"
     ),
-    days: Optional[int] = typer.Option(
-        7, help="Number of days to go back in time in historical search"
+    scan_target_tags: Optional[List[str]] = typer.Option(
+        None, help="Only summarize scan targets from the specified scan target tags"
     ),
+    scan_target_kinds: Optional[List[ScanTargetKind]] = typer.Option(
+        None, help="Only summarize scan targets from the specified kinds"
+    ),
+    alert_severities: Optional[List[AlertSeverity]] = typer.Option(
+        None, help="Only summarize scan targets from the specified severities"
+    )
 ):
-    """
-    Returns summaries of scan results over a period of time, summarizing number of alerts that changed states.
-    """
     client = Client(profile=sdk_config.profile)
-
-    dump_json(client.get_scan_summaries(organization_id, scan_target_ids, days))
-
-
-@app.command(name="scan_following")
-def summary_scan_following(
-    organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
-    following_ids: Optional[List[UUID]] = typer.Option(
-        None,
-        help="Only summarize alerts from the specified following, defaults to all",
-    ),
-    days: Optional[int] = typer.Option(
-        7, help="Number of days to go back in time in historical search"
-    ),
-):
-    """
-    Returns summaries of scan results over a period of time, summarizing number of alerts that changed states.
-    """
-    client = Client(profile=sdk_config.profile)
-
-    dump_json(client.get_scan_summaries(organization_id, following_ids, days))
+    dump_json(
+        client.get_scan_target_detail_summary(
+            organization_id,
+            scan_target_ids,
+            scan_target_tags,
+            scan_target_kinds,
+            alert_severities
+        )
+    )

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -2,11 +2,7 @@ from typing import List, Optional
 from uuid import UUID
 
 import typer
-from zanshinsdk import (
-    Client,
-    AlertSeverity,
-    ScanTargetKind
-)
+from zanshinsdk import AlertSeverity, Client, ScanTargetKind
 
 import src.config.sdk as sdk_config
 from src.lib.utils import dump_json
@@ -28,16 +24,20 @@ def summary_scan_targets_following(
     ),
     alert_severities: Optional[List[AlertSeverity]] = typer.Option(
         None, help="Only summarize scan targets from the specified severities"
-    )
+    ),
+    include_empty_following_tags: Optional[bool] = typer.Option(
+        None, help="Include alerts without tags on the list"
+    ),
 ):
     client = Client(profile=sdk_config.profile)
     dump_json(
         client.get_scan_targets_following_summary(
-            organization_id,
-            following_ids,
-            following_tags,
-            scan_target_kinds,
-            alert_severities
+            organization_id=organization_id,
+            following_ids=following_ids,
+            following_tags=following_tags,
+            scan_target_kinds=scan_target_kinds,
+            alert_severities=alert_severities,
+            include_empty_following_tags=include_empty_following_tags,
         )
     )
 
@@ -56,15 +56,15 @@ def summary_scan_targets_detail(
     ),
     alert_severities: Optional[List[AlertSeverity]] = typer.Option(
         None, help="Only summarize scan targets from the specified severities"
-    )
+    ),
 ):
     client = Client(profile=sdk_config.profile)
     dump_json(
         client.get_scan_target_detail_summary(
-            organization_id,
-            scan_target_ids,
-            scan_target_tags,
-            scan_target_kinds,
-            alert_severities
+            organization_id=organization_id,
+            scan_target_ids=scan_target_ids,
+            scan_target_tags=scan_target_tags,
+            scan_target_kinds=scan_target_kinds,
+            alert_severities=alert_severities,
         )
     )

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -23,10 +23,10 @@ def summary_scan_targets_following(
         None, help="Only summarize scan targets from the specified kinds"
     ),
     alert_severities: Optional[List[AlertSeverity]] = typer.Option(
-        None, help="Only summarize scan targets from the specified severities"
+        None, help="Only summarize alerts with the specified severities"
     ),
     include_empty_following_tags: Optional[bool] = typer.Option(
-        None, help="Include alerts without tags on the list"
+        None, help="Include alerts from scan targets without tags"
     ),
 ):
     client = Client(profile=sdk_config.profile)
@@ -55,7 +55,7 @@ def summary_scan_targets_detail(
         None, help="Only summarize scan targets from the specified kinds"
     ),
     alert_severities: Optional[List[AlertSeverity]] = typer.Option(
-        None, help="Only summarize scan targets from the specified severities"
+        None, help="Only summarize alerts with the specified severities"
     ),
 ):
     client = Client(profile=sdk_config.profile)


### PR DESCRIPTION
### Removing old summaries routes

- summary_alert
- summary_alert_following
- summary_scan
- summary_scan_following

### Adding new granular share ones

- summary_scan_targets_following
- summary_scan_targets_detail

### Issues
#99 #97 