### PR TITLE
fix AWS account status handling for filtering suspended and pending accounts

### DIFF
--- a/src/bin/scan_target.py
+++ b/src/bin/scan_target.py
@@ -406,7 +406,7 @@ def _get_aws_accounts_from_organization(
     for acc in req_aws_accounts["Accounts"]:
         aws_accounts_response.append(
             AWSAccount(
-                Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"]
+                Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"], Status=acc["Status"]
             )
         )
 
@@ -420,7 +420,7 @@ def _get_aws_accounts_from_organization(
         for acc in req_aws_accounts["Accounts"]:
             aws_accounts_response.append(
                 AWSAccount(
-                    Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"]
+                    Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"], Status=acc["Status"]
                 )
             )
         if "NextToken" not in req_aws_accounts:

--- a/src/bin/scan_target.py
+++ b/src/bin/scan_target.py
@@ -406,7 +406,11 @@ def _get_aws_accounts_from_organization(
     for acc in req_aws_accounts["Accounts"]:
         aws_accounts_response.append(
             AWSAccount(
-                Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"], Status=acc["Status"]
+                Id=acc["Id"],
+                Name=acc["Name"],
+                Arn=acc["Arn"],
+                Email=acc["Email"],
+                Status=acc["Status"],
             )
         )
 
@@ -420,7 +424,11 @@ def _get_aws_accounts_from_organization(
         for acc in req_aws_accounts["Accounts"]:
             aws_accounts_response.append(
                 AWSAccount(
-                    Id=acc["Id"], Name=acc["Name"], Arn=acc["Arn"], Email=acc["Email"], Status=acc["Status"]
+                    Id=acc["Id"],
+                    Name=acc["Name"],
+                    Arn=acc["Arn"],
+                    Email=acc["Email"],
+                    Status=acc["Status"],
                 )
             )
         if "NextToken" not in req_aws_accounts:

--- a/src/lib/awsorgrun.py
+++ b/src/lib/awsorgrun.py
@@ -74,8 +74,7 @@ def awsorgrun(
                 )
             )
         elif "Status" in account and (
-            account["Status"] == "SUSPENDED"
-            or account["Status"] == "PENDING_CLOSURE"
+            account["Status"] == "SUSPENDED" or account["Status"] == "PENDING_CLOSURE"
         ):
             logger.info(
                 "skipping account {0:s} ({1:s}) because it is in {2:s} state".format(

--- a/src/lib/awsorgrun.py
+++ b/src/lib/awsorgrun.py
@@ -73,16 +73,15 @@ def awsorgrun(
                     account["Id"], account["Name"]
                 )
             )
-        elif "Status" in account:
-            if (
-                account["Status"] == "SUSPENDED"
-                or account["Status"] == "PENDING_CLOSURE"
-            ):
-                logger.info(
-                    "skipping account {0:s} ({1:s}) because it is in {2:s} state".format(
-                        account["Id"], account["Name"], account["Status"]
-                    )
+        elif "Status" in account and (
+            account["Status"] == "SUSPENDED"
+            or account["Status"] == "PENDING_CLOSURE"
+        ):
+            logger.info(
+                "skipping account {0:s} ({1:s}) because it is in {2:s} state".format(
+                    account["Id"], account["Name"], account["Status"]
                 )
+            )
         elif account["Id"] == org_master_id:
             if target is AWSOrgRunTarget.ALL or target is AWSOrgRunTarget.MASTER:
                 logger.info(

--- a/src/lib/models.py
+++ b/src/lib/models.py
@@ -26,5 +26,5 @@ class AWSAccount(dict):
     Class representing a AWS Account as returned by boto3
     """
 
-    def __init__(self, Id: str, Name: str, Arn: str, Email: str, Onboard: bool = False):
-        dict.__init__(self, Id=Id, Name=Name, Arn=Arn, Email=Email, Onboard=Onboard)
+    def __init__(self, Id: str, Name: str, Arn: str, Email: str, Status: str, Onboard: bool = False):
+        dict.__init__(self, Id=Id, Name=Name, Arn=Arn, Email=Email, Status=Status, Onboard=Onboard)

--- a/src/lib/models.py
+++ b/src/lib/models.py
@@ -26,5 +26,15 @@ class AWSAccount(dict):
     Class representing a AWS Account as returned by boto3
     """
 
-    def __init__(self, Id: str, Name: str, Arn: str, Email: str, Status: str, Onboard: bool = False):
-        dict.__init__(self, Id=Id, Name=Name, Arn=Arn, Email=Email, Status=Status, Onboard=Onboard)
+    def __init__(
+        self,
+        Id: str,
+        Name: str,
+        Arn: str,
+        Email: str,
+        Status: str,
+        Onboard: bool = False,
+    ):
+        dict.__init__(
+            self, Id=Id, Name=Name, Arn=Arn, Email=Email, Status=Status, Onboard=Onboard
+        )


### PR DESCRIPTION
### Description

Adds the `Status` field to the `AWSAccount` model and ensures it's correctly handled in both `scan_target.py` and `awsorgrun.py`.

This change ensures that suspended or pending closure AWS accounts are properly skipped based on their `Status`, while still allowing active accounts to proceed. Previously, the model didn’t capture the `Status` field explicitly, which could lead to silent failures or logic misbehavior when filtering accounts.

Additionally, a small refactor was made to improve the clarity of the conditional check for `Status` in `awsorgrun.py`.

### Tested

- Ran mass onboarding with organizations that include accounts in different statuses (`ACTIVE`, `SUSPENDED`, `PENDING_CLOSURE`).
- Confirmed via logs that suspended/pending accounts were skipped as expected.
- Validated that active accounts proceed to onboarding without issues.
- No errors encountered during CLI execution or scan target listing.

### Issues Addressed

Fixes #120 