### PR TITLE
add CLI support for alerts summaries scans and following over time

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2254,13 +2254,13 @@ files = [
 
 [[package]]
 name = "zanshinsdk"
-version = "2.1.9"
+version = "2.1.10"
 description = "Python SDK to access the Tenchi Security Zanshin API v1"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "zanshinsdk-2.1.9-py3-none-any.whl", hash = "sha256:e6a80101837d17ebcc6ecf315f155d816aa0e741e953730dc5f4b72c0d3730b6"},
-    {file = "zanshinsdk-2.1.9.tar.gz", hash = "sha256:3fef0a8b6833a70886f139a16aa8ac9912124022a5a43d643ba5ac4b88ec7493"},
+    {file = "zanshinsdk-2.1.10-py3-none-any.whl", hash = "sha256:1a3107e078c89f5177446e0dd2c696caf9c563202c48a7df78c3d076c2ccbe89"},
+    {file = "zanshinsdk-2.1.10.tar.gz", hash = "sha256:7171dae4caa8b8c3e4828396c2f147fe04e02dec42836abcbdd2434fec0bc85e"},
 ]
 
 [package.dependencies]
@@ -2404,4 +2404,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "dc01ed1a1014bdcc74b0c5dd2ee2795f85c8355d71db00fdfdb81b5f4d432522"
+content-hash = "9bdc83cc36b0c0a0c0fa539e882a897d2d4460e2df24a63903f0cf5d08cd829a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ boto3-type-annotations = ">=0.3.1"
 typer = "^0.12.3"
 poetry-plugin-export = "^1.8.0"
 urllib3 = "^1.26.20"
-zanshinsdk = "2.1.9"
+zanshinsdk = "2.1.10"
 
 [tool.poetry.group.dev.dependencies]
 moto = {version = "4.0.8", extras = ["organizations", "sts", "s3"]}

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -127,7 +127,7 @@ def summary_following_alerts_over_time(
 ):
     client = Client(profile=sdk_config.profile)
     dump_json(
-        client.get_alerts_over_time(
+        client.get_following_alerts_over_time(
             organization_id=organization_id,
             following_ids=following_ids,
             severities=severities,

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -140,7 +140,7 @@ def summary_following_alerts_over_time(
 def summary_alerts_scans(
     organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
     scan_target_ids: Optional[List[UUID]] = typer.Option(
-        None, help="Only summarize scan targets from the specified scan target ids"
+        None, help="Only summarize alerts from the specified scan target ids"
     ),
     days: Optional[int] = typer.Option(
         7, help="Number of days to go back in time in historical search"

--- a/src/bin/summary.py
+++ b/src/bin/summary.py
@@ -134,3 +134,23 @@ def summary_following_alerts_over_time(
             dates=dates,
         )
     )
+
+
+@app.command(name="alerts_scans")
+def summary_alerts_scans(
+    organization_id: UUID = typer.Argument(..., help="UUID of the organization"),
+    scan_target_ids: Optional[List[UUID]] = typer.Option(
+        None, help="Only summarize scan targets from the specified scan target ids"
+    ),
+    days: Optional[int] = typer.Option(
+        7, help="Number of days to go back in time in historical search"
+    ),
+):
+    client = Client(profile=sdk_config.profile)
+    dump_json(
+        client.get_alerts_summaries_scans(
+            organization_id=organization_id,
+            scan_target_ids=scan_target_ids,
+            days=days,
+        )
+    )


### PR DESCRIPTION
### Description

This PR adds two new commands to the CLI, reflecting recent additions to the SDK:

---

### `get_alerts_summaries_scans`

- Calls: `POST /alerts/summaries/scans`
- Flags:
  - `--organization-id` (required)
  - `--scan-target-ids` (optional, list)
  - `--days` (optional, default = 7)

---

### `get_following_alerts_over_time`

- Calls: `POST /alerts/summaries/following/resolvedovertime`
- Flags:
  - `--organization-id` (required)
  - `--following-ids` (optional, list)
  - `--severities` (optional, list)
  - `--dates` (optional, list of YYYY-MM-DD)

---

Both commands support JSON output and follow the SDK structure.  
This update is part of the ongoing SDK/CLI sync based on the
